### PR TITLE
Fix validation logic

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -64,8 +64,14 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
     },
 
     _bindValueChanged: function() {
-      this.value = this.bindValue;
-      this._validateValue();
+      // If this was called as a result of user input, then |_validateValue|
+      // has already been called in |_onInput|, and it doesn't need to be
+      // called again.
+      if (this.value != this.bindValue) {
+        this.value = this.bindValue;
+        this._validateValue();
+      }
+
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
     },
@@ -75,12 +81,8 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
     },
 
     _validateValue: function() {
-      if (!this.preventInvalidInput) {
-        return;
-      }
-
       var value;
-      if (!this.validity.valid) {
+      if (this.preventInvalidInput && !this.validity.valid) {
         value = this._previousValidInput;
       } else {
         value = this._previousValidInput = this.value;

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -73,6 +73,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(input.value, input.bindValue, 'value equals to bindValue');
       });
 
+      test('changing the input triggers an event', function(done) {
+        var input = fixture('basic');
+
+        input.addEventListener('bind-value-changed', function(value) {
+          assert.equal(input.value, input.bindValue, 'value equals to bindValue');
+          done();
+        });
+
+        input.value = "foo";
+        input._onInput();
+      });
+
       test('default value sets bindValue', function() {
         var input = fixture('has-value');
         assert.equal(input.bindValue, input.value, 'bindValue equals value');


### PR DESCRIPTION
If `preventInvalidInput=false`, `value` and `bindValue` weren't set correctly and no change notifications were sent out. I changed this to basically assume that the input is always valid if `preventInvalidInput=false`.

Also added a test and a small change in `_bindValueChanged` to make sure we don't validate twice (`onInput` calls `_validateValue` which calls `_bindValueChanged`, which really doesn't need to all `validateValue` again)