### PR TITLE
not all input types support selection

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -99,10 +99,21 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
     },
 
     _setValueAndPreserveCaretPosition: function(value) {
-      var start = this.selectionStart;
-      var end = this.selectionEnd;
+      // Not all input types support selection.
+      if (!this.hasOwnProperty(this._canSelect)) {
+        var allowedTypes = ["text", "search", "password", "tel", "url"];
+        this._canSelect = allowedTypes.indexOf(this.type) != -1;
+      }
+
+      if (this._canSelect) {
+        var start = this.selectionStart;
+        var end = this.selectionEnd;
+      }
       this.value = value;
-      this.setSelectionRange(start, end);
+
+      if (this._canSelect) {
+        this.setSelectionRange(start, end);
+      }
     },
 
     /**


### PR DESCRIPTION
This fixes https://github.com/PolymerElements/iron-input/issues/12

We can't decide whether a particular `iron-input` supports selection in its `ready` method since the type isn't set at that time (it's stamped later by the `PaperInputBehavior`)

I did this for all the invalid types, but if we only support text/number/password (as we advertise in `PaperInputBehavior`) then I can change it to a "type != number` check instead.