### PR TITLE
make prevent-invalid-input independent of validation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <div>Prevent invalid input</div>
 
-      can only type numbers: <input is="iron-input" prevent-invalid-input pattern="[0-9]*">
+      can only type numbers: <input is="iron-input" prevent-invalid-input allowed-pattern="[0-9]">
     </section>
 
   </template>

--- a/iron-input.html
+++ b/iron-input.html
@@ -100,10 +100,21 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
     },
 
     _setValueAndPreserveCaretPosition: function(value) {
-      var start = this.selectionStart;
-      var end = this.selectionEnd;
+      // Not all input types support selection.
+      if (!this.hasOwnProperty(this._canSelect)) {
+        var allowedTypes = ["text", "search", "password", "tel", "url"];
+        this._canSelect = allowedTypes.indexOf(this.type) != -1;
+      }
+
+      if (this._canSelect) {
+        var start = this.selectionStart;
+        var end = this.selectionEnd;
+      }
       this.value = value;
-      this.setSelectionRange(start, end);
+
+      if (this._canSelect) {
+        this.setSelectionRange(start, end);
+      }
     },
 
     /**

--- a/iron-input.html
+++ b/iron-input.html
@@ -45,11 +45,19 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
       },
 
       /**
-       * Set to true to prevent the user from entering invalid input or setting
-       * invalid `bindValue`.
+       * Set to true to prevent the user from entering invalid input. The new input characters are
+       * matched with `allowedPattern` if it is set, otherwise it will use the `pattern` attribute if
+       * set, or the `type` attribute (only supported for `type=number`).
        */
       preventInvalidInput: {
         type: Boolean
+      },
+
+      /**
+       * Regular expression to match valid input characters.
+       */
+      allowedPattern: {
+        type: String
       },
 
       _previousValidInput: {
@@ -60,60 +68,62 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
     },
 
     listeners: {
-      'input': '_onInput'
+      'input': '_onInput',
+      'keydown': '_onKeydown'
+    },
+
+    get patternRegExp() {
+      var pattern;
+      if (this.allowedPattern) {
+        pattern = new RegExp(this.allowedPattern);
+      } else if (this.pattern) {
+        pattern = new RegExp(this.pattern);
+      } else {
+        switch (this.type) {
+          case 'number':
+            pattern = /[0-9.,e-]/;
+            break;
+        }
+      }
+      return pattern;
     },
 
     ready: function() {
-      this._ensureValidValue();
       this.bindValue = this.value;
     },
 
     _bindValueChanged: function() {
-      // If this was called as a result of user input, then |_validateValue|
-      // has already been called in |_onInput|, and it doesn't need to be
-      // called again.
-      if (this.value != this.bindValue) {
-        this._setValueAndPreserveCaretPosition(this.bindValue);
-        this._ensureValidValue();
-      }
-
+      this.value = this.bindValue;
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
     },
 
     _onInput: function() {
-      this._ensureValidValue();
+      this.bindValue = this.value;
     },
 
-    _ensureValidValue: function() {
-      var value;
-      /* rename with rc8 */
-      if (this.preventInvalidInput && !this.validate()) {
-        value = this._previousValidInput;
-      } else {
-        value = this._previousValidInput = this.value;
-      }
-      // set value first to not call this method again from _bindValueChanged
-      this._setValueAndPreserveCaretPosition(value);
-      this.bindValue = value;
-      this.validate();
+    _isPrintable: function(keyCode) {
+      var printable =
+        (keyCode > 47 && keyCode < 58)   || // number keys
+        keyCode == 32 || keyCode == 13   || // spacebar & return key
+        (keyCode > 64 && keyCode < 91)   || // letter keys
+        (keyCode > 95 && keyCode < 112)  || // numpad keys
+        (keyCode > 185 && keyCode < 193) || // ;=,-./` (in order)
+        (keyCode > 218 && keyCode < 223);   // [\]' (in order)
+      return printable;
     },
 
-    _setValueAndPreserveCaretPosition: function(value) {
-      // Not all input types support selection.
-      if (!this.hasOwnProperty(this._canSelect)) {
-        var allowedTypes = ["text", "search", "password", "tel", "url"];
-        this._canSelect = allowedTypes.indexOf(this.type) != -1;
+    _onKeydown: function(event) {
+      if (!this.preventInvalidInput) {
+        return;
       }
-
-      if (this._canSelect) {
-        var start = this.selectionStart;
-        var end = this.selectionEnd;
+      var regexp = this.patternRegExp;
+      if (!regexp) {
+        return;
       }
-      this.value = value;
-
-      if (this._canSelect) {
-        this.setSelectionRange(start, end);
+      var thisChar = String.fromCharCode(event.keyCode);
+      if (this._isPrintable(event.keyCode) && !regexp.test(thisChar)) {
+        event.preventDefault();
       }
     },
 

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -103,33 +103,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(input.value, input.bindValue, 'value equals to bindValue');
       });
 
-      test('preserves caret position', function() {
-        var input = fixture('has-value');
-        input.setSelectionRange(2,2);
-        input.bindValue = 'sdfsfsdf';
-        assert.equal(input.selectionStart, 2, 'selectionStart is preserved');
-        assert.equal(input.selectionEnd, 2, 'selectionEnd is preserved');
-      });
-
-      test('prevent invalid input works with bindValue', function() {
-        var input = fixture('prevent-invalid-input');
-        input.bindValue = 'foobar';
-        assert.equal(input.bindValue, '', 'bindValue is empty');
-        assert.equal(input.bindValue, input.value, 'bindValue equals value');
-      });
-
-      test('prevent invalid input works with default value', function() {
-        var input = fixture('prevent-invalid-input-has-value');
-        assert.equal(input.value, '', 'value is empty');
-        assert.equal(input.bindValue, input.value, 'bindValue equals value');
-      });
-
-      test('prevent invalid input works with default bindValue', function() {
-        var input = fixture('prevent-invalid-input-has-bind-value');
-        assert.equal(input.bindValue, '', 'bindValue is empty');
-        assert.equal(input.bindValue, input.value, 'bindValue equals value');
-      });
-
       test('validator used instead of constraints api if provided', function() {
         var input = fixture('has-validator')[1];
         input.value = '123';


### PR DESCRIPTION
@notwaldorf PTAL cc @cdata 

Previously it's difficult to use prevent-invalid-input and
validation together, because often you want to validate the
complete value but want to prevent invalid input while the
value is incomplete. This commit adds a `allowed-pattern`
attribute that lets you define a different pattern to match
new input with.

Support for prevent setting invalid input programmatically
is dropped. Setting value manually when it's invalid is
too error-prone.