### PR TITLE
remove IronFormElementBehavior which breaks everything

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-input",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "An input element with data binding",
   "authors": [
     "The Polymer Authors"
@@ -25,7 +25,6 @@
   "ignore": [],
   "dependencies": {
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^0.9.0",
-    "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"
   },
   "devDependencies": {

--- a/iron-input.html
+++ b/iron-input.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
-<link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
 <script>
 
@@ -52,8 +51,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     extends: 'input',
 
     behaviors: [
-      Polymer.IronValidatableBehavior,
-      Polymer.IronFormElementBehavior
+      Polymer.IronValidatableBehavior
     ],
 
     properties: {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-input/issues/36 and https://github.com/PolymerElements/iron-input/issues/19

`IronFormElementBehavior` also defines a `value` property, which stomps over the input's native `value`property, causing a rift in the space-time continuum. :(

Instead, `IronFormElementBehavior` needs to be added to `paper-input` and any `iron-input` containing brethren.