### PR TITLE
issue with invalid property not setted correctly if type is email aft…

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -211,8 +211,10 @@ is separate from validation, and `allowed-pattern` does not affect how the input
      */
     validate: function() {
       // Empty, non-required input is valid.
-      if (!this.required && this.value == '')
+      if (!this.required && this.value == '') {
+        this.invalid = false;
         return true;
+      }
 
       var valid;
       if (this.hasValidator()) {


### PR DESCRIPTION
…er error

if i have an element like:
&lt;input id="test-invalid" type="email" is="iron-input" invalid="{{invalid}}" /&gt;
and i type a wrong email the invalid property is false as expected.
Then if i clear the field then call validate method, the result is true and the invalid property remain true.