### PR TITLE
ignore special keys when validating input

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -66,6 +66,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         set value to: <input> <button value="value">set</button>
       </p>
     </template>
+    <p>only allows these characters:
+    <code>!@#0123456789</code></p>
+    <input is="iron-input" allowed-pattern="[!@#0-9]" prevent-invalid-input>
+
   </div>
 
   <script>

--- a/iron-input.html
+++ b/iron-input.html
@@ -86,13 +86,18 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       _previousValidInput: {
         type: String,
         value: ''
+      },
+
+      _patternAlreadyChecked: {
+        type: Boolean,
+        value: false
       }
 
     },
 
     listeners: {
       'input': '_onInput',
-      'keydown': '_onKeydown'
+      'keypress': '_onKeypress'
     },
 
     get _patternRegExp() {
@@ -124,26 +129,47 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     },
 
     _onInput: function() {
+      // Need to validate each of the characters pasted if they haven't
+      // been validated inside `_onKeypress` already.
+      if (this.preventInvalidInput && !this._patternAlreadyChecked) {
+        var valid = this._checkPatternValidity();
+        if (!valid) {
+          this.value = this._previousValidInput;
+        }
+      }
+
       this.bindValue = this.value;
+      this._previousValidInput = this.value;
+      this._patternAlreadyChecked = false;
     },
 
-    _isPrintable: function(keyCode) {
-      var printable =
-        (keyCode > 47 && keyCode < 58)   || // number keys
-        keyCode == 32 || keyCode == 13   || // spacebar & return key
-        (keyCode > 64 && keyCode < 91)   || // letter keys
-        (keyCode > 95 && keyCode < 112)  || // numpad keys
-        (keyCode > 185 && keyCode < 193) || // ;=,-./` (in order)
-        (keyCode > 218 && keyCode < 223);   // [\]' (in order)
-      return printable;
+    _isPrintable: function(event) {
+      // What a control/printable character is varies wildly based on the browser.
+      // - most control characters (arrows, backspace) do not send a `keypress` event
+      //   in Chrome, but the *do* on Firefox
+      // - in Firefox, when they do send a `keypress` event, control chars have
+      //   a charCode = 0, keyCode = xx (for ex. 40 for down arrow)
+      // - printable characters always send a keypress event.
+      // - in Firefox, printable chars always have a keyCode = 0. In Chrome, the keyCode
+      //   always matches the charCode.
+      // None of this makes any sense.
+
+      var nonPrintable =
+        (event.keyCode == 8)   ||  // backspace
+        (event.keyCode == 19)  ||  // pause
+        (event.keyCode == 20)  ||  // caps lock
+        (event.keyCode == 27)  ||  // escape
+        (event.keyCode == 45)  ||  // insert
+        (event.keyCode == 46)  ||  // delete
+        (event.keyCode == 144) ||  // num lock
+        (event.keyCode == 145) ||  // scroll lock
+        (event.keyCode > 32 && event.keyCode < 41)   || // page up/down, end, home, arrows
+        (event.keyCode > 111 && event.keyCode < 124); // fn keys
+
+      return !(event.charCode == 0 && nonPrintable);
     },
 
-    // convert printable numpad keys to number keys
-    _correctNumpadKeys: function(keyCode) {
-      return (keyCode > 95 && keyCode < 112) ? keyCode - 48 : keyCode;
-    },
-
-    _onKeydown: function(event) {
+    _onKeypress: function(event) {
       if (!this.preventInvalidInput && this.type !== 'number') {
         return;
       }
@@ -151,10 +177,31 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       if (!regexp) {
         return;
       }
-      var thisChar = String.fromCharCode(this._correctNumpadKeys(event.keyCode));
-      if (this._isPrintable(event.keyCode) && !regexp.test(thisChar)) {
+
+      // Handle special keys and backspace
+      if (event.metaKey || event.ctrlKey || event.altKey)
+        return;
+
+      // Check the pattern either here or in `_onInput`, but not in both.
+      this._patternAlreadyChecked = true;
+
+      var thisChar = String.fromCharCode(event.charCode);
+      if (this._isPrintable(event) && !regexp.test(thisChar)) {
         event.preventDefault();
       }
+    },
+
+    _checkPatternValidity: function() {
+      var regexp = this._patternRegExp;
+      if (!regexp) {
+        return true;
+      }
+      for (var i = 0; i < this.value.length; i++) {
+        if (!regexp.test(this.value[i])) {
+          return false;
+        }
+      }
+      return true;
     },
 
     /**
@@ -166,7 +213,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       // Empty, non-required input is valid.
       if (!this.required && this.value == '')
         return true;
-        
+
       var valid;
       if (this.hasValidator()) {
         valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -48,7 +48,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="prevent-invalid-input">
     <template>
-      <input is="iron-input" prevent-invalid-input pattern="[0-9]*">
+      <input is="iron-input" prevent-invalid-input pattern="[0-9]">
     </template>
   </test-fixture>
 
@@ -110,6 +110,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(input.invalid, 'input is invalid');
       });
 
+      test('prevent invalid input works in _onInput', function() {
+        var input = fixture('prevent-invalid-input');
+        input.value = '123';
+        input._onInput();
+        assert.equal(input.bindValue, '123');
+
+        input.value = '123foo';
+        input._onInput();
+        assert.equal(input.bindValue, '123');
+      });
     });
 
   </script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/gold-cc-input/issues/18, https://github.com/PolymerElements/gold-cc-input/issues/19

To make the `shiftKey` work correctly, I changed `keydown` to `keypress`. This makes all the characters be translated correctly (and now the numpad keys work by magic as well).

To make pasting work correctly, we have to check the entire input value (which we haven't checked on `_keyPress`). I don't know how I can make that better :(