### PR TITLE
Patch dispatchEvent on FF & IE to avoid disabled bugs. Fixes #47

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -100,6 +100,25 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       'keypress': '_onKeypress'
     },
 
+    registered: function() {
+      if (/Firefox|Trident/.test(navigator.userAgent)) {
+        this._origDispatchEvent = this.dispatchEvent;
+        this.dispatchEvent = this._dispatchEventFirefoxIE;
+      }
+    },
+
+    _dispatchEventFirefoxIE: function() {
+      // Due to Firefox bug, events fired on disabled form controls can throw
+      // errors; furthermore, neither IE nor Firefox will actually dispatch
+      // events from disabled form controls; as such, we toggle disable around
+      // the dispatch to allow notifying properties to notify
+      // See issue #47 for details
+      var disabled = this.disabled;
+      this.disabled = false;
+      this._origDispatchEvent.apply(this, arguments);
+      this.disabled = disabled;
+    },
+
     get _patternRegExp() {
       var pattern;
       if (this.allowedPattern) {

--- a/test/disabled-input.html
+++ b/test/disabled-input.html
@@ -1,0 +1,34 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+
+<dom-module id="has-input">
+  <template>
+    <input is="iron-input" bind-value="{{myValue}}" invalid="{{myInvalid}}" disabled id="input">
+  </template>
+</dom-module>
+
+<script>
+
+  Polymer({
+
+    is: 'has-input',
+
+    properties: {
+      myValue: {
+        value: 'foo'
+      }
+    }
+
+  });
+
+</script>

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -24,6 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-input.html">
   <link rel="import" href="letters-only.html">
+  <link rel="import" href="disabled-input.html">
 
 </head>
 <body>
@@ -130,6 +131,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input.value = '123foo';
         input._onInput();
         assert.equal(input.bindValue, '123');
+      });
+
+      test('disabled input doesn\'t throw on Firefox', function() {
+        var el = document.createElement('has-input');
+        assert.equal(el.$.input.bindValue, 'foo');
+        // 2-way bindings won't propagate until attached
+        document.body.appendChild(el);
+        Polymer.dom.flush();
+        assert.strictEqual(el.myInvalid, false);
+        assert.strictEqual(el.$.input.disabled, true);
       });
     });
 


### PR DESCRIPTION
Fixes #47.

Firefox has a bug where calling dispatchEvent on a non-attached and disabled input throws.

This can happen when any notify: true value is set on a disabled input type extension before attached, which can happen via a binding, during configuration of a default value, or by setting a property in ready when it is in the local-DOM of another element (since it won't be attached until after ready).

Additionally, in debugging this, we also found out that Firefox will not actually dispatch events from disabled form controls (regardless of attachment), and IE will not actually dispatch events from ANY disabled element.

After considering how we'd fix this bug in Polymer core, we decided we'd rather just fix it locally in iron-input for now, to avoid adding a complex whitelist system in Polymer core to work around the browser quirks. If this becomes more of a problem outside of iron-input we can consider a more general solution.
