### PR TITLE
allowing tabbing out of inputs

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -157,6 +157,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       // For these keys, ASCII code == browser keycode.
       var anyNonPrintable =
         (event.keyCode == 8)   ||  // backspace
+        (event.keyCode == 9)   ||  // tab
         (event.keyCode == 13)  ||  // enter
         (event.keyCode == 27);     // escape
 


### PR DESCRIPTION
Fixes https://github.com/Polymer/paper-input/issues/184 and the surprise bug of not being able to tab out of gold elements.

@cdata @morethanreal 