### PR TITLE
Quick fix: suppress checking types

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -120,6 +120,9 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       this.bindValue = this.value;
     },
 
+    /**
+     * @suppress {checkTypes}
+     */
     _bindValueChanged: function() {
       if (this.value !== this.bindValue) {
         this.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;


### PR DESCRIPTION
The compiler thinks that `this.bindValue` must be a string, so comparing it to 0 will always be false, which is suspicious.

I tried telling it that `this.bindValue` could be either a string or a number, but then it was unhappy because `this.value` should only be a string, and `this.value` comes in from `<input>` here.