### PR TITLE
add bindValueAsNumber property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,6 +70,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <code>!@#0123456789</code></p>
     <input is="iron-input" allowed-pattern="[!@#0-9]" prevent-invalid-input>
 
+    <p>numeric input with value-as-number:</p>
+    <input is="iron-input" type="number" bind-value-as-number="42">
+
   </div>
 
   <script>

--- a/iron-input.html
+++ b/iron-input.html
@@ -28,6 +28,10 @@ for two-way data binding. `bind-value` will notify if it is changed either by us
 
     <input is="iron-input" bind-value="{{myValue}}">
 
+`iron-input` of type "number" or "date" can use the `bind-value-as-number` property for two-way data binding.
+
+    <input is="iron-input" type="number" bind-value-as-number="{{myNumber}}">
+
 ### Custom validators
 
 You can use custom validators that implement `Polymer.IronValidatorBehavior` with `<iron-input>`.
@@ -46,6 +50,34 @@ is separate from validation, and `allowed-pattern` does not affect how the input
 @hero hero.svg
 @demo demo/index.html
 */
+
+  (function () {
+    'use strict';
+
+    /* Polyfill for `Number.isNaN` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Polyfill */
+    Number.isNaN = Number.isNaN || function(value) {
+      return typeof value === 'number' && isNaN(value);
+    };
+    
+    /* Polyfill for browsers (e.g. IE 10) that don't implement or may have trouble with `valueAsNumber` */
+    var input = document.createElement('input');
+    input.setAttribute('type', 'number');
+    input.setAttribute('value', 2319);
+    if (!('valueAsNumber' in input) || input.value != input.valueAsNumber) {
+      if ('defineProperty' in Object && 'getPrototypeOf' in Object) {
+        Object.defineProperty(Object.getPrototypeOf(input), 'valueAsNumber', {
+          enumerable: true,
+          configurable: true,
+          get: function() {
+            return isNaN(this.value) ? NaN : parseFloat(this.value);
+          },
+          set: function(val) {
+            this.value = isNaN(val) ? '' : parseFloat(val) + '';
+          }
+        });
+      }
+    }
+  }());
 
   Polymer({
 
@@ -68,6 +100,14 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       },
 
       /**
+       * Use this property instead of `value-as-number` for two-way data binding.
+       */
+      bindValueAsNumber: {
+        observer: '_bindValueAsNumberChanged',
+        type: Number
+      },
+
+      /**
        * Set to true to prevent the user from entering invalid input. The new input characters are
        * matched with `allowedPattern` if it is set, otherwise it will use the `pattern` attribute if
        * set, or the `type` attribute (only supported for `type=number`).
@@ -81,7 +121,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
        */
       allowedPattern: {
         type: String,
-        observer: "_allowedPatternChanged"
+        observer: '_allowedPatternChanged'
       },
 
       _previousValidInput: {
@@ -118,6 +158,16 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     },
 
     ready: function() {
+      this._updateBindValues();
+    },
+
+    attached: function () {
+      // handles cases where the bindValueAsNumber is before the setting of type
+      this._updateValueAsNumberIfNeeded();
+    },
+
+    _updateBindValues: function(){
+      this.bindValueAsNumber = this.valueAsNumber;
       this.bindValue = this.value;
     },
 
@@ -125,11 +175,50 @@ is separate from validation, and `allowed-pattern` does not affect how the input
      * @suppress {checkTypes}
      */
     _bindValueChanged: function() {
-      if (this.value !== this.bindValue) {
-        this.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+      if (typeof this.bindValue !== 'string') {
+        // it will trigger another _bindValueChanged event
+        this.bindValue = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue + '';
+      } else {
+        this._updateValueIfNeeded();
+        // manually notify because we don't want to notify until after setting value
+        this.fire('bind-value-changed', {value: this.bindValue});
       }
-      // manually notify because we don't want to notify until after setting value
-      this.fire('bind-value-changed', {value: this.bindValue});
+    },
+
+    _bindValueAsNumberChanged: function() {
+      // ensure it is a number
+      if (typeof this.bindValueAsNumber !== 'number') {
+        // it will trigger another _bindValueAsNumberChanged event
+        // parseFloat would convert '1a' to 1, so we use window.isNaN to handle these cases
+        this.bindValueAsNumber = (typeof this.bindValueAsNumber === 'string' && !window.isNaN(this.bindValueAsNumber)) ? parseFloat(this.bindValueAsNumber) : NaN;
+      } else {
+        this._updateValueAsNumberIfNeeded();
+        // manually notify because we don't want to notify until after setting valueAsNumber
+        this.fire('bind-value-as-number-changed', {value: this.bindValueAsNumber});
+      }
+    },
+
+    _updateValueIfNeeded: function() {
+      if (this.value !== this.bindValue) {
+        this.value = this.bindValue;
+        this._updateBindValues();
+      }
+    },
+
+    _updateValueAsNumberIfNeeded: function() {
+      if ((this.type === 'number' || this.type === 'date') &&
+          this.valueAsNumber !== this.bindValueAsNumber &&
+          // NaN is != from NaN, must check if at least one of them is a number
+          (!Number.isNaN(this.valueAsNumber) || !Number.isNaN(this.bindValueAsNumber))) {
+        // browsers like safari would crash if setting input.valueAsNumber = NaN;
+        // so by setting the value, browser will also set the valueAsNumber
+        if (Number.isNaN(this.bindValueAsNumber)) {
+          this.value = '';
+        } else {
+          this.valueAsNumber = this.bindValueAsNumber;
+        }
+        this._updateBindValues();
+      }
     },
 
     _allowedPatternChanged: function() {
@@ -146,8 +235,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
           this.value = this._previousValidInput;
         }
       }
-
-      this.bindValue = this.value;
+      this._updateBindValues();
       this._previousValidInput = this.value;
       this._patternAlreadyChecked = false;
     },

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -77,6 +77,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="number">
+    <template>
+      <input is="iron-input" type="number" bind-value-as-number="2">
+    </template>
+  </test-fixture>
+
   <template is="dom-bind" id="bind-to-object">
     <input is="iron-input" id="input" bind-value="{{foo}}">
   </template>
@@ -105,6 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('default value sets bindValue', function() {
         var input = fixture('has-value');
+        assert.strictEqual(input.bindValue, 'foobar', 'bindValue equals `foobar`');
         assert.equal(input.bindValue, input.value, 'bindValue equals value');
       });
 
@@ -159,6 +166,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input.value = 'bar123';
         input._onInput();
         assert.equal(input.bindValue, 'foo');
+      });
+
+    });
+
+    suite('number', function(){
+
+      var input;
+      var numbers = ['0', '1', '1.1', '1.1e+1', '00010.00', 1 , 200];
+      var notNumbers = ['a', '1 1', 'a123', '12abc', 'zero'];
+
+      setup(function(){
+        input = fixture('number');
+      });
+
+      test('default bindValueAsNumber sets bindValue, valueAsNumber and value', function() {
+        assert.strictEqual(input.bindValue, '2');
+        assert.strictEqual(input.value, input.bindValue);
+        assert.strictEqual(input.bindValueAsNumber, parseFloat(input.bindValue));
+        assert.strictEqual(input.bindValueAsNumber, input.valueAsNumber);
+      });
+
+      test('changes of bindValue update bindValueAsNumber', function() {
+        for (var i in numbers) {
+          input.bindValue = numbers[i];
+          assert.strictEqual(input.value, input.bindValue);
+          assert.strictEqual(input.valueAsNumber, parseFloat(input.bindValue));
+          assert.strictEqual(input.bindValueAsNumber, input.valueAsNumber);
+        }
+      });
+
+      test('bindValueAsNumber accepts numbers', function() {
+        for (var i in numbers) {
+          input.bindValueAsNumber = numbers[i];
+          assert.isTrue(typeof input.bindValueAsNumber === 'number');
+          assert.isFalse(isNaN(input.valueAsNumber));
+          assert.strictEqual(input.valueAsNumber, input.bindValueAsNumber);
+          assert.strictEqual(input.bindValue, input.value);
+          assert.strictEqual(input.value, input.valueAsNumber + '');
+        }
+      });
+
+      test('bindValueAsNumber doesn\'t accept strings', function() {
+        for (var i in notNumbers) {
+          input.bindValueAsNumber = notNumbers[i];
+          assert.isTrue(typeof input.bindValueAsNumber === 'number');
+          assert.isTrue(isNaN(input.valueAsNumber));
+          assert.isTrue(isNaN(input.bindValueAsNumber));
+          assert.strictEqual(input.bindValue, input.value);
+          assert.strictEqual(input.value, '');
+        }
+      });
+
+      test('notify changes', function() {
+        var bv = sinon.stub();
+        var bvan = sinon.stub();
+        input.addEventListener('bind-value-changed', bv);
+        input.addEventListener('bind-value-as-number-changed', bvan);
+        // set Number should update bindValue and bindValueAsNumber
+        input.bindValueAsNumber = 10;
+        assert.equal(bv.callCount, 1);
+        assert.equal(bvan.callCount, 1);
+        // first notify the about updated value, then about the updated valueAsNumber
+        assert.isTrue(bvan.calledAfter(bv));
+        // count should be increased of one
+        input.bindValueAsNumber = '11';
+        assert.equal(bv.callCount, 2);
+        assert.equal(bvan.callCount, 2);
       });
     });
 


### PR DESCRIPTION
Allows binding on valueAsNumber; it will be updated only for input.type "number" or "date"
http://www.w3.org/TR/2011/WD-html5-20110405/common-input-element-attributes.html#common-input-element-apis

This property is needed to fix https://github.com/PolymerElements/paper-input/issues/170