### PR TITLE
Support boolean false as bindValue.

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -126,7 +126,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
      */
     _bindValueChanged: function() {
       if (this.value !== this.bindValue) {
-        this.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+        this.value = !(this.bindValue || this.bindValue === 0 || this.bindValue === false) ? '' : this.bindValue;
       }
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -141,6 +141,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(input.invalid, 'input is valid');
       });
 
+      test('set bindValue to false', function() {
+        var scope = document.getElementById('bind-to-object');
+        scope.foo = false;
+        assert.isFalse(scope.$.input.bindValue);
+        assert.equal(scope.$.input.value, 'false');
+      });
+
       test('validator used instead of constraints api if provided', function() {
         var input = fixture('has-validator')[1];
         input.value = '123';


### PR DESCRIPTION
Currently, setting `bindValue` to `false` will set the input value to empty.