### PR TITLE
Two way binding and type='number' caret bug fix

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -118,15 +118,25 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     },
 
     ready: function() {
-      this.bindValue = this.value;
+      if (this.type === 'number') {
+        this.bindValue = this.valueAsNumber;
+      } else {
+        this.bindValue = this.value;
+      }
     },
 
     /**
      * @suppress {checkTypes}
      */
     _bindValueChanged: function() {
-      if (this.value !== this.bindValue) {
-        this.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+      if (this.type === 'number'){
+        if (this.valueAsNumber !== this.bindValue) {
+          this.valueAsNumber = !(this.bindValue || this.bindValue === 0) ? 0 : this.bindValue;
+        }
+      }else{
+        if (this.value !== this.bindValue) {
+          this.value = !(this.bindValue || this.bindValue === 0) ? '' : this.bindValue;
+        }
       }
       // manually notify because we don't want to notify until after setting value
       this.fire('bind-value-changed', {value: this.bindValue});
@@ -147,7 +157,11 @@ is separate from validation, and `allowed-pattern` does not affect how the input
         }
       }
 
-      this.bindValue = this.value;
+      if (this.type === 'number') {
+        this.bindValue = this.valueAsNumber;
+      } else {
+        this.bindValue = this.value;
+      }
       this._previousValidInput = this.value;
       this._patternAlreadyChecked = false;
     },

--- a/iron-input.html
+++ b/iron-input.html
@@ -119,7 +119,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
 
     ready: function() {
       if (this.type === 'number') {
-        this.bindValue = this.valueAsNumber;
+        this.bindValue = parseFloat(this.value);
       } else {
         this.bindValue = this.value;
       }
@@ -130,8 +130,8 @@ is separate from validation, and `allowed-pattern` does not affect how the input
      */
     _bindValueChanged: function() {
       if (this.type === 'number'){
-        if (this.valueAsNumber !== this.bindValue) {
-          this.valueAsNumber = !(this.bindValue || this.bindValue === 0) ? 0 : this.bindValue;
+        if (parseFloat(this.value) !== this.bindValue) {
+          this.value = !(this.bindValue || this.bindValue === 0) ? 0 : this.bindValue;
         }
       }else{
         if (this.value !== this.bindValue) {
@@ -158,7 +158,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       }
 
       if (this.type === 'number') {
-        this.bindValue = this.valueAsNumber;
+        this.bindValue = parseFloat(this.value);
       } else {
         this.bindValue = this.value;
       }


### PR DESCRIPTION
Fixes #67 

Yes, this deviates from a pure `<input>`, but this deviations makes sense in the light of a two way binding system where `bindValue` will be bound to a `Number` and thus in the line 

    if (this.valueAsNumber !== this.bindValue) {

they won't be equal, the value will be `set` causing the cursor to jump. 

---

It is very unlikely, but not impossible this could cause backwards compatibility issues with some code. Such code would've had to be written very specifically in that case however to work around this issue.