### PR TITLE
Patch dispatchEvent on FF & IE to avoid disabled bugs. Fixes #47

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -78,7 +78,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
 
       /**
        * Regular expression expressing a set of characters to enforce the validity of input characters.
-       * The recommended value should follow this format: `[a-ZA-Z0-9.+-!;:]` that list the characters 
+       * The recommended value should follow this format: `[a-ZA-Z0-9.+-!;:]` that list the characters
        * allowed as input.
        */
       allowedPattern: {
@@ -101,6 +101,25 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     listeners: {
       'input': '_onInput',
       'keypress': '_onKeypress'
+    },
+
+    registered: function() {
+      if (/Firefox|Trident/.test(navigator.userAgent)) {
+        this._origDispatchEvent = this.dispatchEvent;
+        this.dispatchEvent = this._dispatchEventFirefoxIE;
+      }
+    },
+
+    _dispatchEventFirefoxIE: function() {
+      // Due to Firefox bug, events fired on disabled form controls can throw
+      // errors; furthermore, neither IE nor Firefox will actually dispatch
+      // events from disabled form controls; as such, we toggle disable around
+      // the dispatch to allow notifying properties to notify
+      // See issue #47 for details
+      var disabled = this.disabled;
+      this.disabled = false;
+      this._origDispatchEvent.apply(this, arguments);
+      this.disabled = disabled;
     },
 
     get _patternRegExp() {

--- a/iron-input.html
+++ b/iron-input.html
@@ -104,10 +104,27 @@ is separate from validation, and `allowed-pattern` does not affect how the input
     },
 
     registered: function() {
-      if (/Firefox|Trident/.test(navigator.userAgent)) {
+      // Feature detect whether we need to patch dispatchEvent (i.e. on FF and IE).
+      if (!this._canDispatchEventOnDisabled()) {
         this._origDispatchEvent = this.dispatchEvent;
         this.dispatchEvent = this._dispatchEventFirefoxIE;
       }
+    },
+
+    _canDispatchEventOnDisabled: function() {
+      var input = document.createElement('input');
+      var canDispatch = false;
+      input.disabled = true;
+
+      input.addEventListener('feature-check-dispatch-event', function() {
+        canDispatch = true;
+      });
+
+      try {
+        input.dispatchEvent(new Event('feature-check-dispatch-event'));
+      } catch(e) {}
+
+      return canDispatch;
     },
 
     _dispatchEventFirefoxIE: function() {

--- a/test/disabled-input.html
+++ b/test/disabled-input.html
@@ -1,0 +1,32 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="disabled-input">
+  <template>
+    <input is="iron-input" bind-value="{{myValue}}" invalid="{{myInvalid}}" disabled id="input">
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'disabled-input',
+    properties: {
+      myValue: {
+        value: 'foo'
+      },
+
+      myInvalid: {
+        value: false
+      }
+    }
+  });
+</script>

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -20,6 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../iron-input.html">
   <link rel="import" href="letters-only.html">
+  <link rel="import" href="disabled-input.html">
 
 </head>
 <body>
@@ -88,6 +89,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="dom-bind" id="bind-to-object">
     <input is="iron-input" id="input" bind-value="{{foo}}">
   </template>
+
+  <test-fixture id="disabled-input">
+    <template>
+      <disabled-input></disabled-input>
+    </template>
+  </test-fixture>
 
   <script>
 
@@ -202,8 +209,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input._onInput();
         assert.equal(input.bindValue, 'foo');
       });
-    });
 
+      test('disabled input doesn\'t throw on Firefox', function() {
+        var el = fixture('disabled-input');
+        var input = el.$.input;
+
+        assert.equal(input.bindValue, 'foo');
+
+        assert.strictEqual(el.myInvalid, false);
+        assert.strictEqual(input.disabled, true);
+      });
+    });
   </script>
 
 </body>


### PR DESCRIPTION
Fixes #47.

(this was originally opened in https://github.com/PolymerElements/iron-input/pull/48 a long time ago, but I picked it up here to finally merge it).

Original description
Firefox has a bug where calling dispatchEvent on a non-attached and disabled input throws.

This can happen when any notify: true value is set on a disabled input type extension before attached, which can happen via a binding, during configuration of a default value, or by setting a property in ready when it is in the local-DOM of another element (since it won't be attached until after ready).

Additionally, in debugging this, we also found out that Firefox will not actually dispatch events from disabled form controls (regardless of attachment), and IE will not actually dispatch events from ANY disabled element.

After considering how we'd fix this bug in Polymer core, we decided we'd rather just fix it locally in iron-input for now, to avoid adding a complex whitelist system in Polymer core to work around the browser quirks. If this becomes more of a problem outside of iron-input we can consider a more general solution.

Proof the test originally failed :)
<img width="643" alt="screen shot 2015-12-17 at 11 38 36 am" src="https://cloud.githubusercontent.com/assets/1369170/11880012/8780dec0-a4b3-11e5-8a4c-c67330cb7e6f.png">
