### PR TITLE
call checkValidity() rather than checking .valid

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -235,8 +235,8 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       if (this.hasValidator()) {
         valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
       } else {
-        this.invalid = !this.validity.valid;
-        valid = this.validity.valid;
+        valid = this.checkValidity();
+        this.invalid = !valid;
       }
       this.fire('iron-input-validate');
       return valid;


### PR DESCRIPTION
edit from @notwaldorf: From https://github.com/PolymerElements/paper-input/pull/296. Allows you to listen to the `invalid` event from the nested `<input>`, which is only triggered if `checkValidity` is called. Also, this makes sense since `paper-input-container`'s `_handleValueAndAutoValidate()` also calls `checkValidity`, so there's no real reason why this shouldn't also.