### PR TITLE
apply validation in the correct order

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -261,23 +261,25 @@ is separate from validation, and `allowed-pattern` does not affect how the input
      * @return {boolean} True if the value is valid.
      */
     validate: function() {
-      // Empty, non-required input is valid.
-      if (!this.required && this.value == '') {
-        this.invalid = false;
-        return true;
+      // First, check what the browser thinks. Some inputs (like type=number)
+      // behave weirdly and will set the value to "" if something invalid is
+      // entered, but will set the validity correctly.
+      var valid =  this.checkValidity();
+
+      // Only do extra checking if the browser thought this was valid.
+      if (valid) {
+        // Empty, required input is invalid
+        if (this.required && this.value === '') {
+          valid = false;
+        } else if (this.hasValidator()) {
+          valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
+        }
       }
 
-      var valid;
-      if (this.hasValidator()) {
-        valid = Polymer.IronValidatableBehavior.validate.call(this, this.value);
-      } else {
-        valid = this.checkValidity();
-        this.invalid = !valid;
-      }
+      this.invalid = !valid;
       this.fire('iron-input-validate');
       return valid;
     }
-
   });
 
   /*

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -86,6 +86,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="native-and-custom-validator">
+    <template>
+      <letters-only></letters-only>
+      <input is="iron-input" validator="letters-only" pattern="[a-c]*">
+    </template>
+  </test-fixture>
+
   <template is="dom-bind" id="bind-to-object">
     <input is="iron-input" id="input" bind-value="{{foo}}">
   </template>
@@ -225,6 +232,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         assert.strictEqual(el.myInvalid, false);
         assert.strictEqual(input.disabled, true);
+      });
+
+      test('browser validation beats custom validation', function() {
+        var input = fixture('native-and-custom-validator')[1];
+        // The input allows any letters, but the browser only allows one
+        // of [abc].
+        input.value = 'aaaa';
+        input.validate();
+        assert.isFalse(input.invalid, 'input is valid');
+
+        // The validator allows this, but the browser doesn't.
+        input.value = 'zzz';
+        input.validate();
+        assert.isTrue(input.invalid, 'input is invalid');
       });
     });
   </script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-input/issues/46

The issue was that if you type invalid things (like ---) in `type="number`, the browser sets the `value` to "". Since we were first checking `required` and the `value`, we actually returned `true` in this case. 

I've rejiggered the function to:
 - first check what the browser thinks
 - if the browser thinks this is ok, then do the `required` check, and ask the `validator` if we have one.

It used to be that the validator was checked first. First of all, I'm not sure what it means to have both a `validator` and a browser validation. Take something like `<input pattern="[1-9]*" validator="value-is-exactly-equal-to-cat">`; should the string "cat" be valid? not be valid? who knows. Second, I am not even sure that's right, since inside a form, for example, the form will only look at the browser validity anyway and ignore the validator, so technically browser rules all. I am not opposed to leaving it the original way though.

Here's the kicker: I literally cannot add a test for this. Because security, you can't simulate typing inside and `input`, and because `type=number` is 🍌🍌🍌 , it does not let you programmatically set it to an invalid value. 😂🔫 