### PR TITLE
announce when invalid characters are blocked

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/PolymerElements/iron-input",
   "ignore": [],
   "dependencies": {
+    "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
     "iron-validatable-behavior": "PolymerElements/iron-validatable-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   },

--- a/iron-input.html
+++ b/iron-input.html
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
 <link rel="import" href="../iron-validatable-behavior/iron-validatable-behavior.html">
 
 <script>
@@ -115,6 +116,10 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       }
     },
 
+    created: function() {
+      Polymer.IronA11yAnnouncer.requestAvailability();
+    },
+
     _canDispatchEventOnDisabled: function() {
       var input = document.createElement('input');
       var canDispatch = false;
@@ -183,6 +188,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       if (this.preventInvalidInput && !this._patternAlreadyChecked) {
         var valid = this._checkPatternValidity();
         if (!valid) {
+          this._announceInvalidCharacter('Invalid string of characters not entered.');
           this.value = this._previousValidInput;
         }
       }
@@ -243,6 +249,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       var thisChar = String.fromCharCode(event.charCode);
       if (this._isPrintable(event) && !regexp.test(thisChar)) {
         event.preventDefault();
+        this._announceInvalidCharacter('Invalid character ' + thisChar + ' not entered.');
       }
     },
 
@@ -283,6 +290,10 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       this.invalid = !valid;
       this.fire('iron-input-validate');
       return valid;
+    },
+
+    _announceInvalidCharacter: function(message) {
+      this.fire('iron-announce', { text: message });
     }
   });
 

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 --><html><head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>iron-input ests</title>
+  <title>iron-input tests</title>
   <script src="../../web-component-tester/browser.js"></script>
 </head>
 <body>

--- a/test/iron-input.html
+++ b/test/iron-input.html
@@ -230,8 +230,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         assert.equal(input.bindValue, 'foo');
 
-        assert.strictEqual(el.myInvalid, false);
-        assert.strictEqual(input.disabled, true);
+        assert.isFalse(el.myInvalid);
+        assert.isTrue(input.disabled);
       });
 
       test('browser validation beats custom validation', function() {
@@ -246,6 +246,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         input.value = 'zzz';
         input.validate();
         assert.isTrue(input.invalid, 'input is invalid');
+      });
+    });
+
+    suite('a11y', function() {
+      test('announces invalid characters when _onInput is called', function() {
+        var input = fixture('prevent-invalid-input');
+        input.addEventListener('iron-announce', function(event) {
+          assert.equal(event.detail.text, 'Invalid string of characters not entered.');
+        });
+        input.value = 'foo';
+        input._onInput();
+      });
+
+      test('announces invalid characters on keypress', function() {
+        var input = fixture('prevent-invalid-input');
+        input.addEventListener('iron-announce', function(event) {
+          assert.equal(event.detail.text, 'Invalid character a not entered.');
+        });
+
+        // Simulate key press event.
+        var event = new CustomEvent('keypress', {
+          bubbles: true,
+          cancelable: true
+        });
+        event.charCode = 97 /* a */;
+        input.dispatchEvent(event);
       });
     });
   </script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-input/issues/57.

We announce two messages:
- "Invalid character x not entered" whenever you're typing
- "Invalid string of characters not entered" whenever you paste something or manually call `_onInput`. The reason why this is different is that figuring out what the characters entered were is actually a bit expensive: you only have the string before you called `_onInput` , and the one after, and you would have to manually diff them which isn't trivial (if you paste in the middle of the string, you have to manually go through each character and figure out where the differences are). I'm not sure this is worth it, especially since reading that afterward is weird and potentially super verbose ("oops i accidentally pasted this entire tweet, sigh"). LMK if that doesn't sound reasonable @lpalmaro.

 

