### PR TITLE
Get iron-input jscompiler-friendly

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -130,6 +130,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
          * `input is="iron-input"` value attribute).
          */
         value: {
+          type: String,
           computed: '_computeValue(bindValue)'
         },
 
@@ -160,7 +161,11 @@ is separate from validation, and `allowed-pattern` does not affect how the input
         autoValidate: {
           type: Boolean,
           value: false
-        }
+        },
+          
+        type: {
+          type: String
+        },
       },
 
       observers: [


### PR DESCRIPTION
I'm not 100% on the `type` property, as it seems like it should be declared elsewhere? Maybe it is and I didn't find it?