### PR TITLE
Fix polylint failure

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -160,7 +160,12 @@ is separate from validation, and `allowed-pattern` does not affect how the input
         autoValidate: {
           type: Boolean,
           value: false
-        }
+        },
+          
+       /**
+        * The native input element.
+        */
+        _inputElement: Object,
       },
 
       observers: [


### PR DESCRIPTION
polylint fails with the following error:

Property _inputElement not found in 'properties' for element 'iron-input'

This change explicitly adds the _inputElement property.