### PR TITLE
add type to computed var for Closure

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -130,6 +130,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
          * `input is="iron-input"` value attribute).
          */
         value: {
+          type: String,
           computed: '_computeValue(bindValue)'
         },
 


### PR DESCRIPTION
Closure Compiler with its Polymer pass is unhappy not knowing what type the computed value here is.