### PR TITLE
Set a default value

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -121,7 +121,8 @@ is separate from validation, and `allowed-pattern` does not affect how the input
          * input's `value` property to set a default value.
          */
         bindValue: {
-          type: String
+          type: String,
+          value: ''
         },
 
         /**


### PR DESCRIPTION
`iron-input` 1.x had a default value of `""` (because the native `input` boots up with that value), but `iron-input` 2.x boots up with `undefined`. 